### PR TITLE
Add support for dotnet 6

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Useful.Extensions
 
-A group of useful extensions in C#, supporting .NET Standard 1.6 and .NET Standard 2.0
+A group of useful extensions in C#, supporting .NET 5.0 and NET 6.0
 
 <image src="https://ci.appveyor.com/api/projects/status/github/Tazmainiandevil/Useful.Extensions?branch=master&svg=true">
 <a href="https://badge.fury.io/nu/Useful.Extensions"><img src="https://badge.fury.io/nu/Useful.Extensions.svg" alt="NuGet version" height="18"></a>
@@ -694,8 +694,6 @@ SystemTime.Now = () => new DateTime(2000, 1, 1, 10, 10, 47);
 
 SystemTime.UtcNow = () => new DateTime(2000, 1, 1, 9, 10, 47);
 ```
-
-## .NETSTANDARD 2.0 only
 
 ### Object Helpers
 

--- a/Tests/Useful.Extensions.Tests/DateTimeExtensionsTests.cs
+++ b/Tests/Useful.Extensions.Tests/DateTimeExtensionsTests.cs
@@ -305,7 +305,7 @@ namespace Useful.Extensions.Tests
 
         private DateTime SafeGetTestDate(DateTime dateToStartFrom, int yearsToAdd, int monthsToAdd, int daysToAdd)
         {
-            var futureDate = dateToStartFrom.AddYears(yearsToAdd).AddMonths(monthsToAdd).AddDays(daysToAdd);
+            var futureDate = dateToStartFrom.AddDays(daysToAdd).AddMonths(monthsToAdd).AddYears(yearsToAdd);
             return futureDate;
         }
 

--- a/Tests/Useful.Extensions.Tests/Useful.Extensions.Tests.csproj
+++ b/Tests/Useful.Extensions.Tests/Useful.Extensions.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net5.0</TargetFrameworks>
+    <TargetFrameworks>net5.0;net6.0</TargetFrameworks>
     <LangVersion>latest</LangVersion>
   </PropertyGroup>
 
@@ -18,7 +18,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
     </PackageReference>
-    <DotNetCliToolReference Include="dotnet-xunit" Version="2.3.1" />    
+    <DotNetCliToolReference Include="dotnet-xunit" Version="2.3.1" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Tests/Useful.Extensions.Tests/Useful.Extensions.Tests.csproj
+++ b/Tests/Useful.Extensions.Tests/Useful.Extensions.Tests.csproj
@@ -6,8 +6,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="FluentAssertions" Version="6.1.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.11.0" />
+    <PackageReference Include="FluentAssertions" Version="6.5.1" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.1.0" />
     <PackageReference Include="System.Linq.Queryable" Version="4.3.0" />
     <PackageReference Include="xunit" Version="2.4.1" />
     <PackageReference Include="xunit.runner.console" Version="2.4.1">

--- a/Useful.Extensions.nuspec
+++ b/Useful.Extensions.nuspec
@@ -11,19 +11,11 @@
     <description>$description$</description>
     <tags>tazmainiandevil useful.extensions useful extensions</tags>
     <releaseNotes>$releaseNotes$</releaseNotes>
-    <dependencies>
-      <group targetFramework="netstandard2.0">
-        <dependency id="Microsoft.CSharp" version="4.5.0" />
-      </group>
-      <group targetFramework="netstandard2.0">
-        <dependency id="Microsoft.CSharp" version="4.5.0" />
-      </group>
-    </dependencies>
   </metadata>
   
   <files>
     <file src="LICENSE.txt" target="" />
-    <file src="src\Useful.Extensions\bin\Release\netstandard2.0\Useful.Extensions.dll" target="lib\netstandard2.0\Useful.Extensions.dll" />
-    <file src="src\Useful.Extensions\bin\Release\netstandard1.6\Useful.Extensions.dll" target="lib\netstandard1.6\Useful.Extensions.dll" />
+    <file src="src\Useful.Extensions\bin\Release\net5.0\Useful.Extensions.dll" target="lib\net5.0\Useful.Extensions.dll" />
+    <file src="src\Useful.Extensions\bin\Release\net6.0\Useful.Extensions.dll" target="lib\net6.0\Useful.Extensions.dll" />
   </files>
 </package>

--- a/Useful.Extensions.nuspec
+++ b/Useful.Extensions.nuspec
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<package xmlns="http://schemas.microsoft.com/packaging/2010/07/nuspec.xsd">
+<package xmlns="http://schemas.microsoft.com/packaging/2012/06/nuspec.xsd">
   <metadata>
     <id>$id$</id>
     <version>$version$</version>

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,5 +1,5 @@
 version: 2.0.{build}
-os: Visual Studio 2019
+os: Visual Studio 2022
 configuration: Release
 
 dotnet_csproj:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -14,6 +14,8 @@ dotnet_csproj:
 before_build:
   # Display .NET Core version
   - cmd: dotnet --version
+  # Display .NET SDK versions available
+  - cmd: dotnet --list-sdks
   # Display minimal restore text
   - cmd: dotnet restore --verbosity m
 

--- a/src/Useful.Extensions/Useful.Extensions.csproj
+++ b/src/Useful.Extensions/Useful.Extensions.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net5.0</TargetFrameworks>
+    <TargetFrameworks>net5.0;net6.0</TargetFrameworks>
     <LangVersion>latest</LangVersion>
     <AssemblyVersion>1.0.0</AssemblyVersion>
     <FileVersion>1.0.0</FileVersion>


### PR DESCRIPTION
Added support for dotnet 6.0 by adding `net6.0` to the `csproj` files in the target frameworks.
Updated the NuGet packages in the test project. FluentAssertions -> v6.5.1. Microsoft.NET.Test.Sdk -> 17.1.0.
Fixes #4 

There are two date tests that failed on my machine before I made any changes.  I think they might be a bit flaky due to... well, time.